### PR TITLE
Update template for new task conditions feature

### DIFF
--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -61,7 +61,7 @@ List prerequisites and outline detailed steps in this section for users to setup
 
 <!-- begin template instructions replace -->
 
-Highlight any required [input variables](https://consul-klkdtvr57.vercel.app/docs/nia/configuration#variable_files) or [user-defined metadata](consul.io/docs/nia/configuration#cts_user_defined_meta) and provide an example configuration for Consul Terraform Sync for your module.
+Highlight any required [input variables](https://consul.io/docs/nia/configuration#variable_files) or [user-defined metadata](https://consul.io/docs/nia/configuration#cts_user_defined_meta) and provide an example configuration for Consul Terraform Sync for your module.
 
 <!-- end -->
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -14,9 +14,9 @@ This Terraform module creates an address group for MyProvider Firewall for each 
 
 <!-- replace template instructions below with your content -->
 
-Describe the feature and set of resources the module manages in this section. For example:
+In this section, describe the feature and set of resources the module manages as well as the expected condition type of a task configured with this module. For example:
 
-The module creates an address group if it does not already exist, and applies an existing policy group to the address group when specified for the service.
+The module creates an address group if it does not already exist, and applies an existing policy group to the address group when specified for the service. The module executes on the catalog-services condition, such that it creates and destroys address groups on service registration and deregistration.
 
 <!-- end -->
 
@@ -61,13 +61,18 @@ List prerequisites and outline detailed steps in this section for users to setup
 
 <!-- begin template instructions replace -->
 
-Highlight any required [input variables](https://consul.io/docs/nia/configuration#variable_files) or [user-defined metadata](https://consul.io/docs/nia/configuration#cts_user_defined_meta) and provide an example configuration for Consul Terraform Sync for your module.
+Highlight any required [intermediate input variables](https://consul.io/docs/nia/configuration#variable_files) or [user-defined metadata](https://consul.io/docs/nia/configuration#cts_user_defined_meta). Mention any [Consul Terraform Sync provided input variables](https://consul.io/docs/nia/terraform-modules#optional-input-variables) that are included. Provide an example configuration for Consul Terraform Sync for your module.
 
 <!-- end -->
 
 | User-defined meta | Required | Description |
 |-------------------|----------|-------------|
 | policy_name | true | The name of an existing policy to apply to the address group for the service |
+
+
+| Provided input variables | Included | Description |
+|-------------------|----------|-------------|
+| catalog_services | true | Consul Terraform Sync provided variable for catalog-services condition |
 
 **User Config for Consul Terraform Sync**
 
@@ -81,6 +86,9 @@ task {
   providers      = ["myprovider"]
   services       = ["web", "app"]
   variable_files = ["task-fw-address-group.tfvars"]
+  condition "catalog-services" {
+    source_includes_var = true
+  }
 }
 
 driver "terraform" {

--- a/main.tf
+++ b/main.tf
@@ -18,9 +18,10 @@ terraform {
 resource "myprovider_address_group" "consul_service" {
   for_each = local.consul_services
 
-  name     = "${var.address_group_prefix}${each.key}"
-  tags     = var.address_group_tags
-  policies = [each.value.cts_user_defined_meta["policy_name"]]
+  name         = "${var.address_group_prefix}${each.key}"
+  description  = format("Address group for: %s", join(", ", keys(var.catalog_services)))
+  tags         = var.address_group_tags
+  policies     = [each.value.cts_user_defined_meta["policy_name"]]
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,6 @@
 #
-# var.services is a required input variable for Consul Terraform Sync
+# var.services is a required input variable for Consul Terraform Sync regardless
+# of the type of task condition
 #
 # An example of the services input value:
 # services = {
@@ -37,6 +38,22 @@ variable "services" {
       cts_user_defined_meta = map(string)
     })
   )
+}
+
+#
+# var.catalog_services is a Consul Terraform Sync provided additional input
+# variable for modules to execute on a catalog-services condition
+#
+# An example of the catalog_services input value:
+# catalog_services = {
+#   "api" = ["blue", "green"]
+#   "consul" = []
+#   "web" = ["tag"]
+# }
+#
+variable "catalog_services" {
+  description = "Consul catalog service names and tags monitored by Consul-Terraform-Sync"
+  type = map(list(string))
 }
 
 #


### PR DESCRIPTION
Changes:
 - Fixed some urls to consul.io docs
 - Updated readme template with recommendation to document condition type and any usage of other Consul-Terraform-Sync provided input variables like var.catalog_services
 - Update examples, main.tf, and variables.tf with catalog-services condition

Previews:
 - [README](https://github.com/hashicorp/consul-terraform-sync-template-module/blob/63ddb77c846cc323d2aba739ac4047ec1ba5ee84/README.tmpl.md)
 - [main.tf](https://github.com/hashicorp/consul-terraform-sync-template-module/blob/63ddb77c846cc323d2aba739ac4047ec1ba5ee84/main.tf)
 - [variables.tf](https://github.com/hashicorp/consul-terraform-sync-template-module/blob/63ddb77c846cc323d2aba739ac4047ec1ba5ee84/variables.tf)

Note: planning to merge this PR as part of the release process for CTS 0.2.0