### PR TITLE
Expand README language for different types of conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The template repository includes:
 
 This repository has different branches that can be checked out to see templates for various features that may have different supported variable and documentation recommendations.
  * `main` branch: basic template for default services condition and intermediate input variables
- * `catalog-services-condition-template` branch: template for catalog-service condition
+ * [`catalog-services-condition-template`](https://github.com/hashicorp/consul-terraform-sync-template-module/tree/catalog-services-condition-template) branch: template for catalog-service condition
 
 Visit Terraform documentation for detailed information on [creating modules](https://www.terraform.io/docs/language/modules/develop/index.html) and the [standard module structure](https://www.terraform.io/docs/language/modules/develop/structure.html). Details on Consul Terraform Sync specifications and requirements for modules are outlined in the [official Consul docs](https://www.consul.io/docs/nia/installation/requirements#how-to-create-a-compatible-terraform-module). After you have completed and tested your module, you can share your module by [publishing it on the Terraform Registry](https://www.terraform.io/docs/registry/modules/publish.html) or a [private registry](https://www.terraform.io/docs/registry/private.html).
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The template repository includes:
   * [main.tf](main.tf): the primary entry point for the module
   * [variables.tf](variables.tf): contains variable declarations, including the required `var.services` for Consul Terraform Sync compatibility.
 
+This repository has different branches that can be checked out to see templates for various features that may have different supported variable and documentation recommendations.
+ * `main` branch: basic template for default services condition and intermediate input variables
+ * `catalog-services-condition-template` branch: template for catalog-service condition
+
 Visit Terraform documentation for detailed information on [creating modules](https://www.terraform.io/docs/language/modules/develop/index.html) and the [standard module structure](https://www.terraform.io/docs/language/modules/develop/structure.html). Details on Consul Terraform Sync specifications and requirements for modules are outlined in the [official Consul docs](https://www.consul.io/docs/nia/installation/requirements#how-to-create-a-compatible-terraform-module). After you have completed and tested your module, you can share your module by [publishing it on the Terraform Registry](https://www.terraform.io/docs/registry/modules/publish.html) or a [private registry](https://www.terraform.io/docs/registry/private.html).
 
 A complete example of a compatible Terraform module can be referenced [here](https://registry.terraform.io/modules/CheckPointSW/dynobj-nia/checkpoint/latest).

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -61,7 +61,7 @@ List prerequisites and outline detailed steps in this section for users to setup
 
 <!-- begin template instructions replace -->
 
-Highlight any required [input variables](https://consul-klkdtvr57.vercel.app/docs/nia/configuration#variable_files) or [user-defined metadata](consul.io/docs/nia/configuration#cts_user_defined_meta) and provide an example configuration for Consul Terraform Sync for your module.
+Highlight any required [input variables](https://consul.io/docs/nia/configuration#variable_files) or [user-defined metadata](https://consul.io/docs/nia/configuration#cts_user_defined_meta) and provide an example configuration for Consul Terraform Sync for your module.
 
 <!-- end -->
 

--- a/README.tmpl.md
+++ b/README.tmpl.md
@@ -14,9 +14,9 @@ This Terraform module creates an address group for MyProvider Firewall for each 
 
 <!-- replace template instructions below with your content -->
 
-Describe the feature and set of resources the module manages in this section. For example:
+In this section, describe the feature and set of resources the module manages as well as the expected condition type of a task configured with this module. For example:
 
-The module creates an address group if it does not already exist, and applies an existing policy group to the address group when specified for the service.
+The module creates an address group if it does not already exist, and applies an existing policy group to the address group when specified for the service. The module executes on the default services condition, when there are any changes to the instances of the specified services.
 
 <!-- end -->
 
@@ -61,7 +61,7 @@ List prerequisites and outline detailed steps in this section for users to setup
 
 <!-- begin template instructions replace -->
 
-Highlight any required [input variables](https://consul.io/docs/nia/configuration#variable_files) or [user-defined metadata](https://consul.io/docs/nia/configuration#cts_user_defined_meta) and provide an example configuration for Consul Terraform Sync for your module.
+Highlight any required [input variables](https://consul.io/docs/nia/configuration#variable_files), [user-defined metadata](https://consul.io/docs/nia/configuration#cts_user_defined_meta), or [provided input variables](https://consul.io/docs/nia/terraform-modules#optional-input-variables) and provide an example configuration for Consul Terraform Sync for your module.
 
 <!-- end -->
 


### PR DESCRIPTION
Changes:
 - Fixed some urls to consul.io docs
 - Update some README instructions for potential to have different types of conditions

Preview:
 - [README.md](https://github.com/hashicorp/consul-terraform-sync-template-module/blob/5c7faad306f6d551ff4c2d2704d04ae23753fb6f/README.md)
 - [README.tmpl.md](https://github.com/hashicorp/consul-terraform-sync-template-module/blob/5c7faad306f6d551ff4c2d2704d04ae23753fb6f/README.tmpl.md)